### PR TITLE
In Refrence to Issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,11 @@ Fill in your connection information, and then execute the following command:
 
     hot consume telemetry amqps://my.server:443 tenant
 
-You can use the following flags:
+You can use the following flags to configure the connection:
 
 <dl>
 
-<dt><code>--tlsConn</code></dt>
-<dd>Set to true to enable secure TLS connection</dd>
-<dd>Set to false for no TLS connection(default)</dd>
+
 <dt><code>--insecure</code></dt>
 <dd>Set to true to enable Insecure TLS connection</dd>
 <dt><code>--tlsPath</code></dt>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fill in your connection information, and then execute the following command:
 
     hot consume telemetry amqps://my.server:443 tenant
 
-You can use the following flags to configure the connection:
+You can optionally use the following flags to configure the connection:
 
 <dl>
 
@@ -18,10 +18,11 @@ You can use the following flags to configure the connection:
 <dt><code>--tlsPath</code></dt>
 <dd>Set to path of trusted store file </dd>
 <dt><code>--clientUsername</code></dt>
-<dd>Tenant Username (If Applicaple)</dd>
+<dd>Tenant Username</dd>
 <dt><code>--clientPassword</code></dt>
-<dd>Tenant Password (If Applicaple)</dd>
+<dd>Tenant Password</dd>
 
+*NOTE: if neither --insecure nor --tlsPath are set the AMQP client TLS default is used
 
 </dl>
 

--- a/cmd/consume.go
+++ b/cmd/consume.go
@@ -56,7 +56,7 @@ func consume(messageType string, uri string, tenant string) error {
 	opts := make([]amqp.ConnOption, 0)
 
 	//Enable TLS if required
-	if (tlsConn) {
+	if (uri[0:5] == "amqps") {
 		opts = append(opts, amqp.ConnTLSConfig(createTlsConfig()))
 	}
 	

--- a/cmd/consume.go
+++ b/cmd/consume.go
@@ -55,8 +55,9 @@ func consume(messageType string, uri string, tenant string) error {
 
 	opts := make([]amqp.ConnOption, 0)
 
-	//Enable TLS if required
-	if (uri[0:5] == "amqps") {
+	//Enable TLS if url is secure, and as long as either insecure or tlsPath are set
+	//If neither flag is set, default to AMQP library default
+	if (uri[0:5] == "amqps" && (insecure || tlsPath != "")) {
 		opts = append(opts, amqp.ConnTLSConfig(createTlsConfig()))
 	}
 	

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,8 +49,8 @@ func createTlsConfig() *tls.Config {
 		return &tls.Config{
 			RootCAs: caCertPool,
 		}
-	//InSecure TLS if --insecure=true or if --tlsPath is empty
-	} else{
+	//Connection always insecure if --insecure=true
+	} else {
 		return &tls.Config{
 			InsecureSkipVerify:true,
 		}
@@ -78,9 +78,6 @@ func main() {
 			}
 			if (args[1][0:5] != "amqps" && tlsPath != "") {
 				return errors.New("Cannot have a TLS cert without TLS enabled " )
-			}
-			if (args[1][0:5] == "amqps" && tlsPath == "" && !insecure) {
-				return errors.New("Cannot have a TLS enabled connection that is neither secured with a cert nor Insecure: Please set either --tlsPath or --insecure" )
 			}
 
 			return nil; 


### PR DESCRIPTION
Remove -tlsConfig flag

Enable a TLS connection if user supplies an "amqps" connection endpoint

Provide more Error Handling->
        Throw Error if user tries to pass --insecure=true or --tlsPath for a non TLS connection
        Throw Error if connection is TLS but the  user Dosn't pass either --insecure=true nor a TLS Path

TODO: Apply the TLS setup to http and mqtt  publish functions following approval of the general design by @ctron 

Let me know what you think about this design, glad to change it around if you see fit! 